### PR TITLE
Break up the huge wall of text on Tips, and remove dead links.

### DIFF
--- a/commands.php
+++ b/commands.php
@@ -3,7 +3,7 @@
 <html>
 <head>
 	<title>Commands - Overcast Network Wiki</title>
-	<?php assets(); ?>	
+	<?php assets(); ?>
 </head>
 <body>
 	<?php pageHeader("Commands"); ?>
@@ -40,7 +40,7 @@
 								<div class="page-header">
 									<h1>/join <small>Join a game</small></h1>
 								</div>
-								
+
 								<b>Usage:</b>
 								<p><kbd>/join [team]</kbd></p>
 
@@ -55,7 +55,7 @@
 								<div class="page-header">
 									<h1>/toggle <small>Change your <kbd>/settings</kbd></small></h1>
 								</div>
-								
+
 								<b>Usage:</b>
 								<p><kbd>/toggle [setting]</kbd></p>
 
@@ -125,7 +125,7 @@
 								<div class="page-header">
 									<h1>/msg <small>Sends a private message to a player</small></h1>
 								</div>
-								
+
 								<b>Usage:</b>
 								<p><kbd>/msg [name] [message]</kbd></p>
 
@@ -195,7 +195,7 @@
 						<div class="container">
 							<div class="col-md-9">
 								<div class="page-header">
-									<h1>/mapnext <small>Get the next map in the <kbd>/rot</kbd>ation</small></h1>
+									<h1>/mapnext <small>View the next map set to play</small></h1>
 								</div>
 
 								<b>Usage:</b>
@@ -250,8 +250,6 @@
 								<p><kbd>/lookup [player]</kbd></p>
 								<p><kbd>/l [player]</kbd></p>
 								
-								<b>Other Info:</b>
-								<p>@player can be used to lookup an offline player.</p>
 							</div>
 						</div>
 					</div>
@@ -264,7 +262,7 @@
 
 								<b>Usage:</b>
 								<p><kbd>/server [servername]</kbd></p>
-								
+
 								<b>Other Info:</b>
 								<p>The /server command can also let you teleport to MapDev servers to test out new maps. You type /server and then the name of the Map Developer (ElectroidFilms for example) to acess the server. At most times the server is white-listed, but when it is on, you can try out new maps before they may get added to the offical repository.</p>
 							</div>

--- a/contributors.php
+++ b/contributors.php
@@ -3,7 +3,7 @@
 <html>
 <head>
 	<title>Contributors - Overcast Network Wiki</title>
-	<?php assets(); ?>	
+	<?php assets(); ?>
 	<style>
 		.row {
 			margin-top: 5px;
@@ -42,6 +42,7 @@
 			'zacharycraft777',
 			'BobRingard',
 			'ezekielelin'
+			'CoWinkKeyDinkInc'
 			);
 		shuffle($contributors);
 		foreach ($contributors as $index => $contributor) {

--- a/ranks.json
+++ b/ranks.json
@@ -45,14 +45,14 @@
 			"background-color": "purple"
 		},
 		{
-			"body": "A moderator has a bright red badge on the forums and is represented by a red star in game. They have the abilities of an admin in game except for promotion and other features of CommandBook. They cannot moderate the forums however take note that Overcast Network does not accept moderator requests and the admins choose who to mod next and invite them privately. Do not ask for mod as it greatly decreases your chances of getting it.",
+			"body": "A moderator has a bright red badge on the forums and is represented by a red flair in game. They have the abilities of an admin in game except for promotion and other features of CommandBook. They cannot moderate the forums however take note that Overcast Network does not accept moderator requests and the admins choose who to mod next and invite them privately. Do not ask for mod as it greatly decreases your chances of getting it.",
 			"color": "white",
 			"title": "Moderator",
 			"example": "Beebou",
 			"background-color": "#F20"
 		},
 		{
-			"body": "These are staff that are less experienced than normal moderators. It is basically a stepping stone for new moderators. The admins will see how mature each one is and decide whether or not to mod them completely. After a two week period, the final decision is made. They can do everything that moderators can do except end or setnext maps, and use WorldEdit commands (with the exception of few such as //drain).",
+			"body": "These are staff that are less experienced than normal moderators. It is basically a stepping stone for new moderators. They have a pink flair in game. The admins will see how mature each one is and decide whether or not to mod them completely. After a two week period, the final decision is made. They can do everything that moderators can do except end or setnext maps, and use WorldEdit commands (with the exception of few such as //drain).",
 			"color": "white",
 			"title": "Junior Moderator",
 			"example": "PlasmaCross",

--- a/tips.php
+++ b/tips.php
@@ -29,79 +29,79 @@
 								<h2>A general guide to PvP (Written by Oversoul96)</h2>
 								<hr>
 								<p>
-									If you've played on Project Ares at all, you'll know that there are tons of 
-									different strategies you can use in game play. In this guide, Ill talk about some 
-									tips and tricks I think will help players become more fit to survive in the PvP 
-									onslaught. This guide will focus mainly on DtC maps, because they are the most 
+									If you've played on Project Ares at all, you'll know that there are tons of
+									different strategies you can use in game play. In this guide, I'll talk about some
+									tips and tricks I think will help players become more fit to survive in the PvP
+									onslaught. This guide will focus mainly on DTC maps, because they are the most
 									complex.
 								</p>
 								<h4>
 									<u>The Basics</u>
 								</h4>
 								<p>
-									You all know the drill, grab your gear and get into battle. Most of you will be 
-									able to skip over this section, as it will be very basic stuff, but lets dive 
+									You all know the drill, grab your gear and get into battle. Most of you will be
+									able to skip over this section, as it will be very basic stuff, but lets dive
 									right in anyway.
 								</p>
 								<h5>Getting Supplies</h5>
 								<p>
-									Hopefully all of you know this by now, but shift clicking items sends them 
-									straight into your inventory from chests. If you get to know the contents of 
-									each chest, you can grab all of your gear in less than 10 seconds. If you're a 
-									victim of TNT bombing rushers, you'll want to get your supplies fast, because 
+									Hopefully all of you know this by now, but shift clicking items sends them
+									straight into your inventory from chests. If you get to know the contents of
+									each chest, you can grab all of your gear in less than 10 seconds. If you're a
+									victim of TNT bombing rushers, you'll want to get your supplies fast, because
 									sitting at the chests for over a minute will just make you an easy target.
 								</p>
 								<p>
-									The things you will most likely want to grab are tools. A pick, sword, axe, and 
-									bow should be the first things you grab, along with some building blocks, some 
-									TNT, and some arrows. Take some redstone torches or buttons if you want, but you 
+									The things you will most likely want to grab are tools. A pick, sword, axe, and
+									bow should be the first things you grab, along with some building blocks, some
+									TNT, and some arrows. Take some redstone torches or buttons if you want, but you
 									can always make simple wood pressure plates later.
 								</p>
 								<p>
-									No matter what you're doing, you're always going to want to have armor in the 
-									beginning of the game. Not only will it give you invulnerability to unarmored 
-									rushers, but it will also make you more effective in base defense. If you don't 
-									grab armor because of cannon construction or bow sniping, you're making a big 
+									No matter what you're doing, you're always going to want to have armor in the
+									beginning of the game. Not only will it give you invulnerability to unarmored
+									rushers, but it will also make you more effective in base defense. If you don't
+									grab armor because of cannon construction or bow sniping, you're making a big
 									mistake.
 								</p>
 								<h5>TNT</h5>
 								<p>
-									This is a huge part of DTC maps. Destroying the other team's supplies will give 
-									you a slight advantage in most maps, but setting off TNT will make you a big 
-									target for the enemy team. There are three main ways to blow up the enemy base: 
+									This is a huge part of DTC maps. Destroying the other team's supplies will give
+									you a slight advantage in most maps, but setting off TNT will make you a big
+									target for the enemy team. There are three main ways to blow up the enemy base:
 									cannons, direct assault, and bombing.
 								</p>
 								<p>
-									Cannons are my personal favorite, though I rarely use them. They are very 
-									effective at doing damage when no direct path to the enemy base is available. 
-									There are many different cannon designs you can use, some more effective than 
+									Cannons are my personal favorite, though I rarely use them. They are very
+									effective at doing damage when no direct path to the enemy base is available.
+									There are many different cannon designs you can use, some more effective than
 									others in certain situations.
 								</p>
 								<p>
-									Direct assault is the most dangerous, but most effective way to destroy vital 
-									enemy supplies. Placing giant masses of TNT on the enemy base will do monstrous 
+									Direct assault is the most dangerous, but most effective way to destroy vital
+									enemy supplies. Placing giant masses of TNT on the enemy base will do monstrous
 									damage, with a high chance for kills. If you do this, it would help to have armor,
 									or to do this at the very beginning of a match to catch the enemy off guard.
 								</p>
 								<p>
-									TNT bombing is the last one on the list, but it is also the most cowardly tactic 
-									to use. Using a high vantage point above the enemy base, the player can endlessly 
-									rain TNT onto unsuspecting victims. This method of "carpet bombing" is looked 
-									down upon by most players of PGM, because most bombers spam TNT for kills. If 
-									you want to be a troll, go ahead and rain TNT on the spawn, but prepare to be 
+									TNT bombing is the last one on the list, but it is also the most cowardly tactic
+									to use. Using a high vantage point above the enemy base, the player can endlessly
+									rain TNT onto unsuspecting victims. This method of "carpet bombing" is looked
+									down upon by most players of PGM, because most bombers spam TNT for kills. If
+									you want to be a troll, go ahead and rain TNT on the spawn, but prepare to be
 									yelled at.
 								</p>
 								<h4>
 									<u>Direct Combat</u>
 								</h4>
 								<p>
-									Anyone can swing a sword in this game, but learning to properly wield it is a 
+									Anyone can swing a sword in this game, but learning to properly wield it is a
 									different story. First off, let's talk about blocking.
 								</p>
 								<h5>Blocking</h5>
 								<p>
-									For being a useful mechanic, blocking doesn't get enough love. Blocking can save 
-									your life in some events, but using it wrong can also be deadly. Before we get 
+									For being a useful mechanic, blocking doesn't get enough love. Blocking can save
+									your life in some events, but using it wrong can also be deadly. Before we get
 									into things, lets make sure we know what blocking does.
 								</p>
 								<h6>
@@ -113,70 +113,70 @@
 								</h6>
 								<p>-Reduce falling, fire, or suffocation damage.</p>
 								<p>
-									The thing you might find yourself blocking most is arrows. Whipping out your 
-									sword will magically make you take less damage, and could even save your life. 
-									If you're cornered with an enemy pelting you with arrows, blocking would be a 
-									good idea. If there is an easy escape, running would obviously be the better 
+									The thing you might find yourself blocking most is arrows. Whipping out your
+									sword will magically make you take less damage, and could even save your life.
+									If you're cornered with an enemy pelting you with arrows, blocking would be a
+									good idea. If there is an easy escape, running would obviously be the better
 									choice.
 								</p>
 								<p>
-									Getting cornered with TNT in your face is also a good opportunity to block, but 
-									if you’re too close, you might just end up getting the floor blown out from 
-									underneath you. If youre on a base high in the sky, falling into the void from a 
+									Getting cornered with TNT in your face is also a good opportunity to block, but
+									if you’re too close, you might just end up getting the floor blown out from
+									underneath you. If youre on a base high in the sky, falling into the void from a
 									TNT explosion would obviously be a bad thing.
 								</p>
-								<p>Another important tip for blocking TNT: if you have spare blocks on you, put 
-									them between you and the TNT, and you will only take a half heart of damage, no 
-									matter how close the explosion may be. If you're facing a monstrous TNT explosion, 
+								<p>Another important tip for blocking TNT: if you have spare blocks on you, put
+									them between you and the TNT, and you will only take a half heart of damage, no
+									matter how close the explosion may be. If you're facing a monstrous TNT explosion,
 									then the wall will not be very effective.
 								</p>
 								<p>
-									Blocking is not very effective in melee combat, as it will make you slow and may 
-									even throw off your aim. Alternating between left and right click for your main 
-									attack is not something I would recommend, as it will end up doing less damage 
+									Blocking is not very effective in melee combat, as it will make you slow and may
+									even throw off your aim. Alternating between left and right click for your main
+									attack is not something I would recommend, as it will end up doing less damage
 									in the long run.
 								</p>
 								<h4>
 									<u>Sword Fighting</u>
 								</h4>
 								<p>
-									There are a number of ways to engage in close-range combat, but a lot of these 
+									There are a number of ways to engage in close-range combat, but a lot of these
 									strategies will be useless if you have a bad connection to the server.
 								</p>
 								<h5>Strafing </h5>
 								<p>
-									One of the simplest ways to attack is in a circular pattern around your enemy. 
-									Rushing straight at your target is not smart. If you want to run straight at your 
-									target, you'll want to jump to the side just before you attack. Having the speed 
+									One of the simplest ways to attack is in a circular pattern around your enemy.
+									Rushing straight at your target is not smart. If you want to run straight at your
+									target, you'll want to jump to the side just before you attack. Having the speed
 									boost of sprinting will give you an easier time in battle as well.
 								</p>
 								<h5>Jump Crits</h5>
 								<p>
-									I don't find these to be very useful, but starting off an attack with a jump can 
-									be advantageous. Just don't overdo the jumps, or they will probably throw off 
+									I don't find these to be very useful, but starting off an attack with a jump can
+									be advantageous. Just don't overdo the jumps, or they will probably throw off
 									your momentum in a battle.
 								</p>
 								<h5>Knockback Launch</h5>
 								<p>
-									Being one of my favorite things to do, you will need a quick finger to pull this 
-									off. After every hit you land on an enemy, quickly double tap <kbd>a</kbd> and 
-									hit the enemy again to send him flying double the distance of a normal 
-									knockback. If you're really good, you can hit an enemy three times or more. 
-									Because of the slight delay you will have before the enemy goes flying, getting 
+									Being one of my favorite things to do, you will need a quick finger to pull this
+									off. After every hit you land on an enemy, quickly double tap <kbd>a</kbd> and
+									hit the enemy again to send him flying double the distance of a normal
+									knockback. If you're really good, you can hit an enemy three times or more.
+									Because of the slight delay you will have before the enemy goes flying, getting
 									multiple strikes should be fairly simple.
 								</p>
 								<h5>Chasing</h5>
 								<p>
-									When chasing a fleeing enemy, DO NOT spam your sword to try and hit him. All this 
-									will do is disable your sprint, because Minecraft will think you've struck an 
-									enemy while the enemy was actually too far away to take damage. Wait until you're 
+									When chasing a fleeing enemy, DO NOT spam your sword to try and hit him. All this
+									will do is disable your sprint, because Minecraft will think you've struck an
+									enemy while the enemy was actually too far away to take damage. Wait until you're
 									close enough for a guaranteed hit before trying to attack.
 								</p>
 								<h5>Things you should not do in a sword fight </h5>
 								<p>
-									Running backwards and swinging your sword will let your enemy have an easier time 
-									hitting you, while he remains out of your reach (because thats just how this game 
-									works). Running away would be a better tactic than swinging while walking 
+									Running backwards and swinging your sword will let your enemy have an easier time
+									hitting you, while he remains out of your reach (because thats just how this game
+									works). Running away would be a better tactic than swinging while walking
 									backwards.
 								</p>
 								<h5>Combos</h5>
@@ -184,7 +184,7 @@
 									This is the act of continuously hitting someone and laying down many hits on them.
 								</p>
 								<p>
-									This technique makes it particularly hard for your opponent to counter and break 
+									This technique makes it particularly hard for your opponent to counter and break
 									out of the non-stop hits.
 								</p>
 								<h5>Block Hitting</h5>
@@ -195,117 +195,117 @@
 									It is achieved by spamming both your left and right mouse buttons simultaneously.
 								</p>
 								<p>
-									This technique is effective when your opponent is laying down hits on you at the 
+									This technique is effective when your opponent is laying down hits on you at the
 									same time as you are hitting him.
 								</p>
 								<p>
-									By doing this, each hit that your opponent makes while you are blocking will be 
+									By doing this, each hit that your opponent makes while you are blocking will be
 									reduced by half.
 								</p>
 								<h4>
 									<u>Destroy the Core</u>
 								</h4>
 								<p>
-									Right here is where the fun begins. I will be showing you some of my own tactics, 
-									as well as other things I think will help you all for these maps. The main topics 
-									I will be discussing are the core, stealth, bridging, and speed. I will also tell 
+									Right here is where the fun begins. I will be showing you some of my own tactics,
+									as well as other things I think will help you all for these maps. The main topics
+									I will be discussing are the core, stealth, bridging, and speed. I will also tell
 									you a few tricks for surviving in a losing battle.
 								</p>
 								<h5>The Core</h5>
 								<p>
-									This is your goal. Leaking lava from the core is simple enough, but we can make 
-									it even simpler. Most players see the bottom as the only option available for 
-									mining the core, but the most effective place to mine is usually near the top of 
-									the core. Look for these weak spots in the core, and you'll be able to destroy it 
-									with ease. If the core has water underneath it, you can either lead the lava away 
-									from the water, or you can make a small + sign and cut out the center for the 
+									This is your goal. Leaking lava from the core is simple enough, but we can make
+									it even simpler. Most players see the bottom as the only option available for
+									mining the core, but the most effective place to mine is usually near the top of
+									the core. Look for these weak spots in the core, and you'll be able to destroy it
+									with ease. If the core has water underneath it, you can either lead the lava away
+									from the water, or you can make a small + sign and cut out the center for the
 									lava to leak through.
 								</p>
 								<p>
-									If you're not attacking the core, the enemy base, or using a cannon, don't just 
-									stand around looking for things to shoot. Take a good look at the core every few 
-									seconds to make sure it's safe. Playing without a plan will end up causing you to 
-									lose. And if you're trying to look for ways to barricade the core, dont do it. 
-									Barricading the core with blocks will make it a lot easier for hidden enemies to 
+									If you're not attacking the core, the enemy base, or using a cannon, don't just
+									stand around looking for things to shoot. Take a good look at the core every few
+									seconds to make sure it's safe. Playing without a plan will end up causing you to
+									lose. And if you're trying to look for ways to barricade the core, dont do it.
+									Barricading the core with blocks will make it a lot easier for hidden enemies to
 									mine the core.
 								</p>
 								<h5>Stealth</h5>
 								<p>
-									Stealth is easily the biggest part of storming an enemy base. Rushing into a 
-									bunch of enemies looking for kills will not work. If you have a good vantage 
-									point, look for a break in the enemy defense to make your attack. Make sure 
-									you're always crouching, too. Don't ever assume that you're perfectly safe, 
-									because someone might catch a glimpse of you. Done correctly, you can easily get 
+									Stealth is easily the biggest part of storming an enemy base. Rushing into a
+									bunch of enemies looking for kills will not work. If you have a good vantage
+									point, look for a break in the enemy defense to make your attack. Make sure
+									you're always crouching, too. Don't ever assume that you're perfectly safe,
+									because someone might catch a glimpse of you. Done correctly, you can easily get
 									to your objective without being spotted.
 								</p>
 								<p>
-									As for hiding places, creating a box around your self is usually a lot more 
-									effective than it sounds. Just don't make it in the middle of the base, or it 
-									will look suspicious. Also, remember that you can always make more area for you 
-									to walk around on. Dig inside of a wall if you need to, and dig to vulnerable 
-									parts of the base through there. You can even line the inside of a base with TNT 
-									and ignite it completely undetected. Don't just run across an open field covering 
+									As for hiding places, creating a box around your self is usually a lot more
+									effective than it sounds. Just don't make it in the middle of the base, or it
+									will look suspicious. Also, remember that you can always make more area for you
+									to walk around on. Dig inside of a wall if you need to, and dig to vulnerable
+									parts of the base through there. You can even line the inside of a base with TNT
+									and ignite it completely undetected. Don't just run across an open field covering
 									the ground with TNT.
 								</p>
 								<h5>Bridging</h5>
 								<p>
-									Bridging is simple, but if you don't want to die while doing it, there are a few 
+									Bridging is simple, but if you don't want to die while doing it, there are a few
 									things you can do.
 								</p>
 								<p>
-									Quick bridging is, as it sounds, the fastest way to directly bridge to an enemy 
+									Quick bridging is, as it sounds, the fastest way to directly bridge to an enemy
 									base, but it also puts you in the most vulnerable position.
 								</p>
 								<p>If you take a look at this picture</p>
 								<img src="http://i49.tinypic.com/2a4xod2.png" class="img-rounded">
 								<p>
-									While bridging from the red ship to the blue ship, you will want to stand on the 
-									side that the green arrow is on, because most archers will be striking you from 
-									the left part of the blue ship, sending you to the right. If you're standing on 
+									While bridging from the red ship to the blue ship, you will want to stand on the
+									side that the green arrow is on, because most archers will be striking you from
+									the left part of the blue ship, sending you to the right. If you're standing on
 									the left, the knockback shouldnt be enough to send you flying off in one hit.
 								</p>
 								<p>
-									Making a bridge with rails is slower, but is also safer. Make sure you place the 
-									railing blocks before you place the actual bridge, so that youll always have a 
-									railing. You shouldn't get knocked backwards toward the void, so making the 
+									Making a bridge with rails is slower, but is also safer. Make sure you place the
+									railing blocks before you place the actual bridge, so that youll always have a
+									railing. You shouldn't get knocked backwards toward the void, so making the
 									railing first will give you a better chance to live a shot from an enemy.
 								</p>
 								<p>
-									If you want to retreat from a bridge, stay on the side that is opposite from the 
-									knockbacks you are receiving, as told before. Also, do NOT jump while sprinting, 
-									or the knockback will be greater than usual, and will surely knock you off of a 
+									If you want to retreat from a bridge, stay on the side that is opposite from the
+									knockbacks you are receiving, as told before. Also, do NOT jump while sprinting,
+									or the knockback will be greater than usual, and will surely knock you off of a
 									bridge.
 								</p>
 								<h5>Speed</h5>
 								<p>
-									The last thing I want to talk about, but it is still fairly simple. As all of you 
-									should know, jumping while sprinting makes you faster, but another thing I want 
+									The last thing I want to talk about, but it is still fairly simple. As all of you
+									should know, jumping while sprinting makes you faster, but another thing I want
 									to talk about is sprint-jump boosting.
 								</p>
 								<p>
-									Sprint-jump boosting is an easy way to outrun an enemy in an area that is two 
-									blocks high. If you repeatedly jump against the two-high ceiling while sprinting, 
+									Sprint-jump boosting is an easy way to outrun an enemy in an area that is two
+									blocks high. If you repeatedly jump against the two-high ceiling while sprinting,
 									you can gain a huge speed boost.
 								</p>
 								<h5>What to do in a losing battle</h5>
 								<p>
-									If you're out of supplies, you might think you're screwed. The first thing you'll 
-									want to do is look around your base for any stray items from a dead player. 
+									If you're out of supplies, you might think you're screwed. The first thing you'll
+									want to do is look around your base for any stray items from a dead player.
 									Usually any amount of supplies should be enough to get you back on your feet.
 								</p>
 								<p>
-									Out of picks? Grab some TNT. TNT can easily be ignited with a pressure plate, 
-									made of only two wood. Place a TNT on one of your diamond or iron patches to get 
+									Out of picks? Grab some TNT. TNT can easily be ignited with a pressure plate,
+									made of only two wood. Place a TNT on one of your diamond or iron patches to get
 									easy access to tools and armor.
 								</p>
 								<p>
-									Is there a bridge? Run to the enemy base and steal some supplies from them. If 
-									it's late enough in the game for you to be out of supplies, then stealthily 
-									taking supplies from the enemy base should be simple while everyone is in 
+									Is there a bridge? Run to the enemy base and steal some supplies from them. If
+									it's late enough in the game for you to be out of supplies, then stealthily
+									taking supplies from the enemy base should be simple while everyone is in
 									disarray.
 								</p>
 								<p>
-									The most important thing to do is never give up. You can always come back and 
+									The most important thing to do is never give up. You can always come back and
 									win, no matter how bad it gets.
 								</p>
 							</div>
@@ -319,67 +319,67 @@
 								<ol>
 									<p>
 										<li>
-											<strong> You don't have to pull it back all the way.</strong> Though you deal 
-											critical damage by pulling it back all the way, some situations warrant a 
-											faster fire rate simply to keep your opponent knocked back and at a distance. 
-											It's a good idea to simply spam arrows at a charging enemy wielding a sword 
+											<strong> You don't have to pull it back all the way.</strong> Though you deal
+											critical damage by pulling it back all the way, some situations warrant a
+											faster fire rate simply to keep your opponent knocked back and at a distance.
+											It's a good idea to simply spam arrows at a charging enemy wielding a sword
 											to hold him in place until you feel it's safe to deal a finishing blow.
 										</li>
 									</p>
 									<p>
 										<li>
-											<strong>Walls don't always help.</strong> It seems counterintuitive, but 
-											walls with battlements or firing ports make it easier for enemies to expect 
-											where you will pop up, easier to sight in, and harder for you to have a wide 
-											view of the battlefield. Visibility and mobility is key to using a bow 
-											effectively; you only need to build walls if you know where the enemy is 
-											and you are under fire. You should always try to be mobile as well; try 
+											<strong>Walls don't always help.</strong> It seems counterintuitive, but
+											walls with battlements or firing ports make it easier for enemies to expect
+											where you will pop up, easier to sight in, and harder for you to have a wide
+											view of the battlefield. Visibility and mobility is key to using a bow
+											effectively; you only need to build walls if you know where the enemy is
+											and you are under fire. You should always try to be mobile as well; try
 											moving unpredictably after shots.
 										</li>
 									</p>
 									<p>
 										<li>
-											<strong>Fire at a high angle.</strong> Though this takes some practice, 
-											enemies behind cover can be sussed out by firing at a high arc—you don't 
-											pull back as much on the arrow and lob death from above. Following that 
-											theme, in a map like Sand Wars, a good tactic is to shoot up the floor with 
-											arrows; when the sand falls, the arrows dislodge themselves and you can 
-											sometimes get a lucky kill. This arrow-falling tactic also applies to blocks 
-											covered with arrows that are broken—this works really well for enemies 
-											tunneling under in Battle of Lyndannise: If you block up the hole that the 
-											enemies exit out of, and cover it in arrows, when the opponent breaks the 
-											block to attack you he will immediately be killed by the dislodged arrows. 
-											Furthermore, if you have really good timing, you can do the same on other 
-											maps like Race for Victory etc. Pillar up above the enemy, make a skypath, 
-											and shoot up a (optimally glass) block full of arrows. When an enemy races 
+											<strong>Fire at a high angle.</strong> Though this takes some practice,
+											enemies behind cover can be sussed out by firing at a high arc—you don't
+											pull back as much on the arrow and lob death from above. Following that
+											theme, in a map like Sand Wars, a good tactic is to shoot up the floor with
+											arrows; when the sand falls, the arrows dislodge themselves and you can
+											sometimes get a lucky kill. This arrow-falling tactic also applies to blocks
+											covered with arrows that are broken—this works really well for enemies
+											tunneling under in Battle of Lyndannise: If you block up the hole that the
+											enemies exit out of, and cover it in arrows, when the opponent breaks the
+											block to attack you he will immediately be killed by the dislodged arrows.
+											Furthermore, if you have really good timing, you can do the same on other
+											maps like Race for Victory etc. Pillar up above the enemy, make a skypath,
+											and shoot up a (optimally glass) block full of arrows. When an enemy races
 											under you, you can break the block and drop a deadly arrow bomb from above.
 										</li>
 									</p>
 									<p>
 										<li>
-											<strong>Know your limits.</strong> Fully charged arrows do minimal damage to 
-											foes with full diamond armour, and take a long time to kill even iron armour, 
-											so sometimes shooting at them, especially when you're trying to sneak around, 
-											can arouse investigation in the area and give you away. However, even if they 
-											don't damage that much, they are good for holding enemies back at a range 
-											with their knockback. Furthermore, arrows are invaluable in dislodging 
-											opponents contstructing cannons, bridges, etc. and disrupting their 
-											activities. Arrow fire in general does produce a hesitant psychological 
+											<strong>Know your limits.</strong> Fully charged arrows do minimal damage to
+											foes with full diamond armour, and take a long time to kill even iron armour,
+											so sometimes shooting at them, especially when you're trying to sneak around,
+											can arouse investigation in the area and give you away. However, even if they
+											don't damage that much, they are good for holding enemies back at a range
+											with their knockback. Furthermore, arrows are invaluable in dislodging
+											opponents contstructing cannons, bridges, etc. and disrupting their
+											activities. Arrow fire in general does produce a hesitant psychological
 											effect on the enemy.
 										</li>
 									</p>
 									<p>
 										<li>
-											<strong>Play as a team.</strong> Seems like a no-brainer, but I see a lot of 
-											people not paying attention to who exactly they are shooting at and their 
-											significance–Always provide covering fire to people who are charging in to 
-											attack with a sword, and always take care to select vulnerable or high-value 
-											targets. Remember to make power shots when picking off unarmoured or exposed 
-											targets: jumping or sprinting forward while shooting a high-powered shot can 
-											give your arrow a boost. Always keep in mind that with every enemy you kill, 
-											you reduce their strength to attack your allies, so it's usually a better 
-											idea to kill three unarmoured aggressors, who will land some hits regardless 
-											of their survivability, than it is to try and wear down one heavily armoured 
+											<strong>Play as a team.</strong> Seems like a no-brainer, but I see a lot of
+											people not paying attention to who exactly they are shooting at and their
+											significance–Always provide covering fire to people who are charging in to
+											attack with a sword, and always take care to select vulnerable or high-value
+											targets. Remember to make power shots when picking off unarmoured or exposed
+											targets: jumping or sprinting forward while shooting a high-powered shot can
+											give your arrow a boost. Always keep in mind that with every enemy you kill,
+											you reduce their strength to attack your allies, so it's usually a better
+											idea to kill three unarmoured aggressors, who will land some hits regardless
+											of their survivability, than it is to try and wear down one heavily armoured
 											foe.
 										</li>
 									</p>
@@ -393,32 +393,29 @@
 								<h2>YLO's PvP Guide</h2>
 								<hr>
 								<p>
-									So I decided to rename it because it sounds a bit better than 'Attempt at pvp 
+									So I decided to rename it because it sounds a bit better than 'Attempt at pvp
 									guide'.
 								</p>
 								<p>
-									Here is my first attempt at a guide. This is mainly for tactics and is aimed for 
+									Here is my first attempt at a guide. This is mainly for tactics and is aimed for
 									those having difficulty with gaining pvp and not sure what to do.
 								</p>
 								<p>
 									There are a number of different tactics what you can use.
 								</p>
 								<p>
-									Also all these people saying 'Don't YOLO into battle, it'll get you nowhere' 
-									that is completely false. That is exactly why I got my nickname on OCN cos of 
-									that and now I find myself 'tanking' (taking an extremely long time to be killed 
-									even though you have the clear disadvantage) and quite often coming out on top. 
+									Also all these people saying 'Don't YOLO into battle, it'll get you nowhere'
+									that is completely false. That is exactly why I got my nickname on OCN cos of
+									that and now I find myself 'tanking' (taking an extremely long time to be killed
+									even though you have the clear disadvantage) and quite often coming out on top.
 									My record is a 10v1 on the Overcast Network (I have no idea how I did it).
 								</p>
 								<p>
-									NOTE: The best method is to just practice and look at the people who are 
-									considered 'pros' and mold it to your playstyle. Some people who you should look 
+									NOTE: The best method is to just practice and look at the people who are
+									considered 'pros' and mold it to your playstyle. Some people who you should look
 									at are:
 								</p>
 								<ul>
-									<li>
-										HattoWolf -&nbsp;<a href="http://www.youtube.com/user/HattoWolfPVP">http://www.youtube.com/user/HattoWolfPVP</a>
-									</li>
 									<li>
 										ApacheBlitz -&nbsp;<a href="http://www.youtube.com/user/ApacheBlitz7">http://www.youtube.com/user/ApacheBlitz7</a>
 									</li>
@@ -447,13 +444,7 @@
 										MyTerriblePvP -&nbsp;<a href="https://www.youtube.com/user/MyTerriblePvP">https://www.youtube.com/user/MyTerriblePvP</a>
 									</li>
 									<li>
-										MrM00se -&nbsp;<a href="http://www.youtube.com/user/MrM00se100">http://www.youtube.com/user/MrM00se100</a>&nbsp;(Example of how teamwork can overcome disadvantaged situations).
-									</li>
-									<li>
 										Jehovas_Witness -&nbsp;<a href="http://www.youtube.com/user/JehovahsPlays">http://www.youtube.com/user/JehovahsPlays</a>
-									</li>
-									<li>
-										MK325 -&nbsp;<a href="http://www.youtube.com/user/MK325tv">http://www.youtube.com/user/MK325tv</a>
 									</li>
 									<li>
 										Unphair -&nbsp;<a href="http://www.youtube.com/user/Phair64">http://www.youtube.com/user/Phair64</a>
@@ -471,138 +462,135 @@
 										ginie1 -&nbsp;<a href="http://www.youtube.com/user/MrGinie12">http://www.youtube.com/user/MrGinie12</a>
 									</li>
 									<li>
-										Shene0509 -&nbsp;<a href="http://www.youtube.com/channel/UCmgF0OHi_3XltodhBahCfGQ">http://www.youtube.com/channel/UCmgF0OHi_3XltodhBahCfGQ</a>
-									</li>
-									<li>
 										OllieGamerz -&nbsp;<a href="http://www.youtube.com/user/OllieGamerz">http://www.youtube.com/user/OllieGamerz</a>&nbsp;(Overcast Network, Team Leading (Spanish))
 									</li>
 								</ul>
 								<p>
-									Also check out the channels they linked to or the people they fight. More often 
+									Also check out the channels they linked to or the people they fight. More often
 									than not those are very good pvpers too.
 								</p>
 								<p>
 									OK anyway:
 								</p>
-								<b>Strafing</b>: Strafing is not what people think and certainly not what a lot 
-								of guides suggest. I see it a lot, it says 'going round in a full circle' 
-								basically all strafing implies is movement around your enemy whilst taking 
+								<b>Strafing</b>: Strafing is not what people think and certainly not what a lot
+								of guides suggest. I see it a lot, it says 'going round in a full circle'
+								basically all strafing implies is movement around your enemy whilst taking
 								little/0 damage.
 								<br>
 								<ul>
 									<li>
-										<b>Full circle strafe</b>: The most talked about and referred section of 
-										strafing. Basically implies doing a full circle around your opponent. This 
-										usually works in a random situation as the player generally finds it 
-										difficult to keep up with your movements and the hit boxes are unable to be 
+										<b>Full circle strafe</b>: The most talked about and referred section of
+										strafing. Basically implies doing a full circle around your opponent. This
+										usually works in a random situation as the player generally finds it
+										difficult to keep up with your movements and the hit boxes are unable to be
 										detected whilst the player is circle strafing.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Semi circle strafe</b>: This implies doing a semi circle to your opponent 
-										and just following that pattern. It is probably the one I use most as I can 
-										maintain a good view on my opponent and keep them in one section. You can 
-										also change it up a bit and add crits to the end of the semi circle or run 
+										<b>Semi circle strafe</b>: This implies doing a semi circle to your opponent
+										and just following that pattern. It is probably the one I use most as I can
+										maintain a good view on my opponent and keep them in one section. You can
+										also change it up a bit and add crits to the end of the semi circle or run
 										through your opponent.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Quarter circle strafe</b>: Basically the exact same as&nbsp;<b>semi 
-										circle&nbsp;</b>and&nbsp;<b>full circle strafe&nbsp;</b>but you do a quarter. 
-										Hard to do and often fails as your don't have rapid movements but it is 
-										little enough to be able to be hit. I would advice against using it often but 
+										<b>Quarter circle strafe</b>: Basically the exact same as&nbsp;<b>semi
+										circle&nbsp;</b>and&nbsp;<b>full circle strafe&nbsp;</b>but you do a quarter.
+										Hard to do and often fails as your don't have rapid movements but it is
+										little enough to be able to be hit. I would advice against using it often but
 										can help in rapid unpredictable situations.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Jitter/Little strafe</b>: I call it jitter others call it little. This is 
-										mostly used when getting a combo on your oppenent. All you do is tap a and d, 
-										or whatever your side to side button is, whilst going forward and you get a 
-										jitter strafe. It is hard to counter as the rapid movements make the hit box 
-										on your player move about rapidly and go a little bit 'spazzy'. This allows 
-										you to maintain a rapid movement forward and in 1.6 and below it was a crazy 
-										tactic that was over used in a lot of types of pvp but was extremely deadly. 
-										Now due to the toggle sprint you often find yourself over taking your enemy. 
-										This is probably the best one for tight situations where there is enough open 
+										<b>Jitter/Little strafe</b>: I call it jitter others call it little. This is
+										mostly used when getting a combo on your oppenent. All you do is tap a and d,
+										or whatever your side to side button is, whilst going forward and you get a
+										jitter strafe. It is hard to counter as the rapid movements make the hit box
+										on your player move about rapidly and go a little bit 'spazzy'. This allows
+										you to maintain a rapid movement forward and in 1.6 and below it was a crazy
+										tactic that was over used in a lot of types of pvp but was extremely deadly.
+										Now due to the toggle sprint you often find yourself over taking your enemy.
+										This is probably the best one for tight situations where there is enough open
 										ground for a strafe and your close to an edge.
 									</li>
 								</ul>
 								<br>
-								<b>Block hitting</b>: Block hitting is good, don't get me wrong but it is 
-								overused as hell. I would advice using block hitting in these situations. You do 
-								this by clicking left and right alternately or at the same time. Either works 
+								<b>Block hitting</b>: Block hitting is good, don't get me wrong but it is
+								overused as hell. I would advice using block hitting in these situations. You do
+								this by clicking left and right alternately or at the same time. Either works
 								fine.
 								<br>
 								<ul>
 									<li>
-										<b>In a tunnel or extremely small space</b>&nbsp;where strafing wouldn't help 
-										you. (If it is 2 block by 1 block then spam your jump key whilst block 
+										<b>In a tunnel or extremely small space</b>&nbsp;where strafing wouldn't help
+										you. (If it is 2 block by 1 block then spam your jump key whilst block
 										hitting.)
 									</li>
 									<li>
-										<b>When being grouped on.</b>&nbsp;You can mix this up with strafing, you can 
-										basically Shepard a group of players into a combined space and kill them and 
-										they won't really know what is going on and just swing and hit randomly. If 
-										you are in the centre aswell of a big group fight try jump critting aswell. 
-										This will do extra damage, take damage off you and allow you to be knocked 
-										back out of the group. It will help you for a short amount of time but if the 
+										<b>When being grouped on.</b>&nbsp;You can mix this up with strafing, you can
+										basically Shepard a group of players into a combined space and kill them and
+										they won't really know what is going on and just swing and hit randomly. If
+										you are in the centre aswell of a big group fight try jump critting aswell.
+										This will do extra damage, take damage off you and allow you to be knocked
+										back out of the group. It will help you for a short amount of time but if the
 										group is derpy you could come out with a few kills.
 									</li>
 									<li>
 										<b>When you and your enemy are going to hit each other at around the same time</b>.
-										&nbsp;I watch it a lot and also find myself doing it, where a each 
-										player knows that they are going to hit each other but carry on trying to out 
-										strafe one another. This basically just allows you to keep going for a bit 
+										&nbsp;I watch it a lot and also find myself doing it, where a each
+										player knows that they are going to hit each other but carry on trying to out
+										strafe one another. This basically just allows you to keep going for a bit
 										longer and give you the health edge over your opponent.
 									</li>
 								</ul>
-								Also you don't have to stand still or just walk forward whilst blockhitting. You 
+								Also you don't have to stand still or just walk forward whilst blockhitting. You
 								can move to the side and kind of strafe your opponent whilst block hitting.
 								<br><br>
-								<b>Critical hits</b>: Critical hits are over used too but deadly and irritating. 
-								I do see people who use it a lot and get countered easily by strafing. To crit 
-								you jump up in the air and hit your enemy, you should see particles fly off 
+								<b>Critical hits</b>: Critical hits are over used too but deadly and irritating.
+								I do see people who use it a lot and get countered easily by strafing. To crit
+								you jump up in the air and hit your enemy, you should see particles fly off
 								them.&nbsp;<b>Also critical and block hitting generally go hand in hand.</b>
 								<br>
 								Use it in these situations.
 								<br>
 								<ul>
 									<li>
-										<b>When the enemy can't see you</b>. Basically go up behind them or too their 
-										side and crit them, they'll be taken off guard and it takes time to react and 
-										usually they end up dying. It is a quick way to kill them but if they know 
+										<b>When the enemy can't see you</b>. Basically go up behind them or too their
+										side and crit them, they'll be taken off guard and it takes time to react and
+										usually they end up dying. It is a quick way to kill them but if they know
 										their stuff they could counter you or run away.
 									</li>
 									<li>
-										<b>When in tunnels</b>.&nbsp;<b><i>ONLY&nbsp;</i></b>use this with 
-										block hitting. I can't tell you how many people I've killed cos they just 
+										<b>When in tunnels</b>.&nbsp;<b><i>ONLY&nbsp;</i></b>use this with
+										block hitting. I can't tell you how many people I've killed cos they just
 										critical hit me whilst I critical hit them and block hit.
 									</li>
 									<li>
-										<b>Whilst in a group</b>. Either with our against you. With you get rid of 
-										the enemy pretty quickly, against it allows you to do extra damage whilst a 
-										person just sprinting on the floor generally knocks you out of the group 
+										<b>Whilst in a group</b>. Either with our against you. With you get rid of
+										the enemy pretty quickly, against it allows you to do extra damage whilst a
+										person just sprinting on the floor generally knocks you out of the group
 										(if against use it with block hitting).
 									</li>
 									<li>
 										<b>At the end of a strafe</b>. I use it and it works. Especially with a&nbsp;
-										<b>semi circle strafe</b>. It allows my hit box to be harder to hit 
-										(minecraft hit boxes are the derpiest thing ever) whilst dealing extra 
+										<b>semi circle strafe</b>. It allows my hit box to be harder to hit
+										(minecraft hit boxes are the derpiest thing ever) whilst dealing extra
 										damage. I also use it so I can go back around the&nbsp;
 										<b>semi circle strafe</b>.
 									</li>
 									<li>
-										<b>When charging head on at a player</b>. Either jump over them or to the 
-										side. Whilst often predictable and over used due to minecraft hit boxes it 
+										<b>When charging head on at a player</b>. Either jump over them or to the
+										side. Whilst often predictable and over used due to minecraft hit boxes it
 										works really well.&nbsp;
 									</li>
 									<li>
-										<b>When on the back foot</b>. This just allows you to make static gameplay 
-										whilst dealing a bit of extra damage. Usually when you know you're going to 
-										lose but want to give them some extra damage just so your teammates can pick 
+										<b>When on the back foot</b>. This just allows you to make static gameplay
+										whilst dealing a bit of extra damage. Usually when you know you're going to
+										lose but want to give them some extra damage just so your teammates can pick
 										them off.
 									</li>
 								</ul>
@@ -610,63 +598,63 @@
 								<br><br>
 								<ul>
 									<li>
-										<b>Don't pull all the way back in close situations</b>. You don't need to and 
+										<b>Don't pull all the way back in close situations</b>. You don't need to and
 										you get more arrows into your enemy whilst keeping them back.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>When running use a bow</b>. When running back and an enemy is running 
-										after you, jump, turn around and put a shot into them. This knocks them back 
-										and flinches then for a fraction of a second, in this you can turn the fight 
+										<b>When running use a bow</b>. When running back and an enemy is running
+										after you, jump, turn around and put a shot into them. This knocks them back
+										and flinches then for a fraction of a second, in this you can turn the fight
 										around and combo them to death.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Machine gun</b>. When low just bow spam them to crap. I usually do this 
-										when I'm on 5 or 4 hearts as it gives me time to regen whilst keeping them 
-										back. Basically just tap your right click a bit (hold down for a fraction 
+										<b>Machine gun</b>. When low just bow spam them to crap. I usually do this
+										when I'm on 5 or 4 hearts as it gives me time to regen whilst keeping them
+										back. Basically just tap your right click a bit (hold down for a fraction
 										of a second) and this will maintain distance between you and your opponent.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Matsuzen tactic</b>. (I don't think Matsuzen invented it but he is the 
-										first person I saw use it and it works really well). Just before a fight 
-										either run away and shoot them or just shoot them. Put a couple of shots 
-										into them and then melee fight them. This lowers damage to you and makes the 
+										<b>Matsuzen tactic</b>. (I don't think Matsuzen invented it but he is the
+										first person I saw use it and it works really well). Just before a fight
+										either run away and shoot them or just shoot them. Put a couple of shots
+										into them and then melee fight them. This lowers damage to you and makes the
 										fight shorter.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Practice</b>. Play on servers such as Minez or RMCT where your bow pvp 
-										will improve massively and you learn more.&nbsp;<b>Bow pvp is a lot more 
-										about practice and experience than guides</b>. Here is a video what could 
+										<b>Practice</b>. Play on servers such as Minez or RMCT where your bow pvp
+										will improve massively and you learn more.&nbsp;<b>Bow pvp is a lot more
+										about practice and experience than guides</b>. Here is a video what could
 										help with practice too.&nbsp;
 										<a href="http://www.youtube.com/watch?v=E1ulNMIsfQQ">http://www.youtube.com/watch?v=E1ulNMIsfQQ</a>
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<b>Bow battles&nbsp;</b>- First thing to remember, is that the rate of fire 
-										and your accuracy are crucial to win duels. It is always better, to get in 
-										close enough for you to fire quicker shots then far away, where one can 
-										easily miss or have their shot dodged. Quicker shots will give you a better 
-										chance of damaging your opponent, in the same concept as fighting a 
-										swordsman. However, the enemy can return the fire too this time. Firing an 
-										arrow will greatly slow you down. This is an archer's most vulnerable point, 
-										and is the point you must take to your advantage when attacking another 
-										archer. Never linger on a shot, or concentrate too much on an aim. Fire your 
-										arrow and immediately move a few blocks to the left or right. Take another 
-										quick shot and move again. A master archer is able to hit an enemy and then 
-										dodge the enemy arrow and return fire immediately. Shoot while the enemy is 
-										charging his bow, then dodge once he releases the bowstring, and immediately 
-										charge your bow and take a shot again. Every hit on the enemy will knock 
-										them back, messing up their aim, every hit on you will do the same, possibly 
-										breaking your shoot-and-dodge pattern. Never hold the string for too long, 
-										for you are greatly slowed and that is when you cannot dodge the enemy arrow. 
+										<b>Bow battles&nbsp;</b>- First thing to remember, is that the rate of fire
+										and your accuracy are crucial to win duels. It is always better, to get in
+										close enough for you to fire quicker shots then far away, where one can
+										easily miss or have their shot dodged. Quicker shots will give you a better
+										chance of damaging your opponent, in the same concept as fighting a
+										swordsman. However, the enemy can return the fire too this time. Firing an
+										arrow will greatly slow you down. This is an archer's most vulnerable point,
+										and is the point you must take to your advantage when attacking another
+										archer. Never linger on a shot, or concentrate too much on an aim. Fire your
+										arrow and immediately move a few blocks to the left or right. Take another
+										quick shot and move again. A master archer is able to hit an enemy and then
+										dodge the enemy arrow and return fire immediately. Shoot while the enemy is
+										charging his bow, then dodge once he releases the bowstring, and immediately
+										charge your bow and take a shot again. Every hit on the enemy will knock
+										them back, messing up their aim, every hit on you will do the same, possibly
+										breaking your shoot-and-dodge pattern. Never hold the string for too long,
+										for you are greatly slowed and that is when you cannot dodge the enemy arrow.
 										Speed will always beat power.
 									</li>
 								</ul>
@@ -674,37 +662,37 @@
 								<br>
 								<ul>
 									<li>
-										<i><b>Fire Arrows</b></i>: When you shoot an arrow through a lava curtain, 
-										the arrow will become a fire arrow. This can light an opposing player on fire 
-										if the arrow hits them. Fire will drain their health very quickly and slow 
-										them down, allowing you to get easier shots on them. This tactic can be 
-										extremely useful to pressure the opposing team on certain maps such as RFV2 
+										<i><b>Fire Arrows</b></i>: When you shoot an arrow through a lava curtain,
+										the arrow will become a fire arrow. This can light an opposing player on fire
+										if the arrow hits them. Fire will drain their health very quickly and slow
+										them down, allowing you to get easier shots on them. This tactic can be
+										extremely useful to pressure the opposing team on certain maps such as RFV2
 										or RFV.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<i><b>Shooting through water</b></i><b>:</b>&nbsp;Water significantly slows 
-										down the speed of&nbsp;arrows, causing it to dip downward a little bit. When 
-										shooting at a target underwater, aim a little higher than usual. The lower 
+										<i><b>Shooting through water</b></i><b>:</b>&nbsp;Water significantly slows
+										down the speed of&nbsp;arrows, causing it to dip downward a little bit. When
+										shooting at a target underwater, aim a little higher than usual. The lower
 										the target is underwater, the higher you should aim in order to hit them.
 									</li>
 								</ul>
 								<ul>
 									<li>
-										<i><b>Interaction with blocks</b></i><b>:</b>&nbsp;Arrows can activate wooden 
-										pressure plates, set off wooden buttons and destroy boats. These can be 
-										extremely useful tactics in many maps on Overcast.&nbsp;Shooting wooden 
-										pressure plates can set off TNT on the enemy side, especially useful if 
-										someone is trying to Icarus. Many people also use boats to rush maps, and 
-										shooting their boats will render them extremely vulnerable in the water. 
-										Shooting wooden buttons is possibly the hardest out of the 3 but if you land 
-										the shot can be the hardest to counter. The only time you'd be shooting would 
-										be to counter a cannon. It is possible as I did it in a scrim against Bolt 
-										and managed to destroy their Whiskey cannon. The only time you'll usually be 
-										shooting at buttons are on cannons similar to whiskeys (unless you approach 
-										them from behind). Using arrows on cannons (wooden objects) can be extremely 
-										useful and can often leave the cannoneer amazed and wondering what just 
+										<i><b>Interaction with blocks</b></i><b>:</b>&nbsp;Arrows can activate wooden
+										pressure plates, set off wooden buttons and destroy boats. These can be
+										extremely useful tactics in many maps on Overcast.&nbsp;Shooting wooden
+										pressure plates can set off TNT on the enemy side, especially useful if
+										someone is trying to Icarus. Many people also use boats to rush maps, and
+										shooting their boats will render them extremely vulnerable in the water.
+										Shooting wooden buttons is possibly the hardest out of the 3 but if you land
+										the shot can be the hardest to counter. The only time you'd be shooting would
+										be to counter a cannon. It is possible as I did it in a scrim against Bolt
+										and managed to destroy their Whiskey cannon. The only time you'll usually be
+										shooting at buttons are on cannons similar to whiskeys (unless you approach
+										them from behind). Using arrows on cannons (wooden objects) can be extremely
+										useful and can often leave the cannoneer amazed and wondering what just
 										happened which stops them from preventing the damage their TNT will cause.
 									</li>
 								</ul>
@@ -714,207 +702,233 @@
 								<br>
 								<ul>
 									<li>
-										<b>Try Blitz</b>. Blitz (chaos/cronus) means you only have 1 life per match 
-										(except a few maps), this means you have a smarter playstyle and be more 
-										conservative in what you do. It allows you to keep a cool head and analyse 
-										situations faster whilst being under pressure. Situations such as being 
-										outnumbered called for a quick and speedy mind whilst being able to find 
-										innovative ideas to overcome your opponents and put them into action 
+										<b>Try Blitz</b>. Blitz (chaos/cronus) means you only have 1 life per match
+										(except a few maps), this means you have a smarter playstyle and be more
+										conservative in what you do. It allows you to keep a cool head and analyse
+										situations faster whilst being under pressure. Situations such as being
+										outnumbered called for a quick and speedy mind whilst being able to find
+										innovative ideas to overcome your opponents and put them into action
 										effectively.
 									</li>
+									<br>
 									<li>
 										<b>Rage (Gamemode)</b>. Rage is the exact same as&nbsp;<b>Blitz</b>&nbsp;
-										however it is 1 hit/shot 1 kill. This means you have to be super wary, have 
-										fast reflexes and be accurate. Lacking in any of these means you will most 
-										likely die. Ping in sword combat can be ping orientated yes but if you play 
-										evasively (jumping to side, strafe) you usually come out on top. Bow is the 
-										best and most OP (Over Powered) weapon in Rage. It allows for long distance 
-										kills without causing much threat to yourself. Don't be hasty, take your time 
-										because a slip up means you're out. Don't go for a long range shot because it 
-										is highly unlikely to land. If you want to improve patience, reflex, 
+										however it is 1 hit/shot 1 kill. This means you have to be super wary, have
+										fast reflexes and be accurate. Lacking in any of these means you will most
+										likely die. Ping in sword combat can be ping orientated yes but if you play
+										evasively (jumping to side, strafe) you usually come out on top. Bow is the
+										best and most OP (Over Powered) weapon in Rage. It allows for long distance
+										kills without causing much threat to yourself. Don't be hasty, take your time
+										because a slip up means you're out. Don't go for a long range shot because it
+										is highly unlikely to land. If you want to improve patience, reflex,
 										awareness and accuracy Rage is a great gamemode.
 									</li>
+									<br>
 									<li>
-										<b>Be accurate</b>. Look at reflex games, accuracy games. It'll increase it 
+										<b>Be accurate</b>. Look at reflex games, accuracy games. It'll increase it
 										and you find yourself not having to click as fast to kill your enemy.
 									</li>
+									<br>
 									<li>
-										<b>Click fast</b>. Only use this if you have a generally OK accuracy or if 
-										you want to go crazy. Clicking fast gets rid of accuracy a bit but some can 
-										do both well and efficiently. Try something called jitter clicking, I can't 
+										<b>Click fast</b>. Only use this if you have a generally OK accuracy or if
+										you want to go crazy. Clicking fast gets rid of accuracy a bit but some can
+										do both well and efficiently. Try something called jitter clicking, I can't
 										really explain it but here's a video to show what it is.&nbsp;
 										<a href="http://www.youtube.com/watch?v=bRGL2KBIPyM">http://www.youtube.com/watch?v=bRGL2KBIPyM</a>
 									</li>
+									<br>
 									<li>
-										<b>Countering Bowspam</b>.&nbsp;Move side to side in unpredictable movements. 
-										This confuses your opponent and makes the archer unable to focus you. Never 
-										stand in the same line for for than 1 second and never repeat your movements. 
-										This can mean jumping and side movements. As long as your general direction 
+										<b>Countering Bowspam</b>.&nbsp;Move side to side in unpredictable movements.
+										This confuses your opponent and makes the archer unable to focus you. Never
+										stand in the same line for for than 1 second and never repeat your movements.
+										This can mean jumping and side movements. As long as your general direction
 										is forward, be as random as possible!
 									</li>
+									<br>
 									<li>
-										<b>Using terrain</b>. When using terrain you need to remember certain things. 
-										If your enemy is close to the edge, try to knock them towards it and they 
-										will most likely fall off. If it goes downwards try to hit them towards it as 
-										they take extra damage from fall damage. If below them just side strafe, 
-										press <kbd>a</kbd> then <kbd>d</kbd> and repeat, you get an advantage from being below your 
-										opponent and moving side to side makes your hit box even harder to get 
-										(I have never been hit whilst doing this). To counter someone below you just 
-										jump over them, it's simple, and then they lose the advantage and are taken 
-										off guard. When using a bow try to get high ground, high ground gives you a 
+										<b>Using terrain</b>. When using terrain you need to remember certain things.
+										If your enemy is close to the edge, try to knock them towards it and they
+										will most likely fall off. If it goes downwards try to hit them towards it as
+										they take extra damage from fall damage. If below them just side strafe,
+										press <kbd>a</kbd> then <kbd>d</kbd> and repeat, you get an advantage from being below your
+										opponent and moving side to side makes your hit box even harder to get
+										(I have never been hit whilst doing this). To counter someone below you just
+										jump over them, it's simple, and then they lose the advantage and are taken
+										off guard. When using a bow try to get high ground, high ground gives you a
 										HUGE advantage in archery.
 									</li>
+									<br>
 									<li>
-										<b>Eating Golden Apples</b>. If low on health and you have little risk of 
-										being in a battle again, do not eat your golden apples immediately 
-										afterwards. If you do you get around 6/5 seconds of regeneration 2, 
-										if you wait for your previous apple to wear down you can get 10 seconds 
-										(5 seconds of regeneration 2 per apple)&nbsp;of regeneration 2. It heals you 
-										4 hearts per apple and gives you an additional 2 hearts. Due to this you 
+										<b>Eating Golden Apples</b>. If low on health and you have little risk of
+										being in a battle again, do not eat multiple golden apples the second after you ate one.
+									  If you do you get around 6/5 seconds of regeneration 2, if you wait for
+										your previous apple to wear down you can get 10 seconds
+								    (5 seconds of regeneration 2 per apple)&nbsp;of regeneration 2. It heals you
+										4 hearts per apple and gives you an additional 2 hearts. Due to this you
 										can get 8 hearts instead of 6/5.
 									</li>
+									<br>
 									<li>
-										<b>Finding the right FOV</b>. This can help a lot and people switch around a 
-										lot. Finding the right FOV helps you to concentrate and see more. Generally 
-										people either go for Normal, 90 or Quake Pro. The higher the FOV the more you 
+										<b>Finding the right FOV</b>. This can help a lot and people switch around a
+										lot. Finding the right FOV helps you to concentrate and see more. Generally
+										people either go for Normal, 90 or Quake Pro. The higher the FOV the more you
 										can see; here is a comparison of Normal and Quake Pro&nbsp;
-										<a href="http://imgur.com/RLWOkLc,ZIGk6wg#1">http://imgur.com/RLWOkLc,ZIGk6wg#1</a>. 
-										As you can clearly see I am able to see more with Quake Pro, however in order 
-										to do this the objects become smaller to the eye. People who bow often use 
-										Normal and people who use sword often pick 90. Mess around, you can always 
-										find a setting you like. Personally I've switched between 4 different FOVs, 
-										Quake Pro, 100, 90 and Normal (Currently using Normal). It can help with 
-										accuracy too as it is something what your eye is most comfortable with and 
+										<a href="http://imgur.com/RLWOkLc,ZIGk6wg#1">http://imgur.com/RLWOkLc,ZIGk6wg#1</a>.
+										As you can clearly see I am able to see more with Quake Pro, however in order
+										to do this the objects become smaller to the eye. People who bow often use
+										Normal and people who use sword often pick 90. Mess around, you can always
+										find a setting you like. Personally I've switched between 4 different FOVs,
+										Quake Pro, 100, 90 and Normal (Currently using Normal). It can help with
+										accuracy too as it is something what your eye is most comfortable with and
 										you can foresee things easier.
 									</li>
+									<br>
 									<li>
-										<b>Control your anger</b>. Anger can be an up and a down. It can help you to 
-										get motivated and you generally perform better if you get motivated. However 
+										<b>Control your anger</b>. Anger can be an up and a down. It can help you to
+										get motivated and you generally perform better if you get motivated. However
 										if you get angry because of a negative reason (which it generally is), stop. I
-										t makes you worse of a player, knocks your confidence and lowers your 
-										teamwork abilities. It also knocks your senses needed in pvp. Everyone does 
-										it and will do it but try your best to avoid it. Stop, take a break, maybe 
-										join observers. Do something to distract yourself or analyse what happened, 
-										find a way to improve yourself and overcome it. Whilst it is hard because 
-										your frustrated if you pull it off, you will be able to have a broader mind 
+										t makes you worse of a player, knocks your confidence and lowers your
+										teamwork abilities. It also knocks your senses needed in pvp. Everyone does
+										it and will do it but try your best to avoid it. Stop, take a break, maybe
+										join observers. Do something to distract yourself or analyse what happened,
+										find a way to improve yourself and overcome it. Whilst it is hard because
+										your frustrated if you pull it off, you will be able to have a broader mind
 										set when coming to the next battle.
 									</li>
+									<br>
 									<li>
-										<b>Stay calm</b>. This means in every situation. Don't get worried, stay calm 
-										and concentrate. If you stay calm you find it easier to control your actions. 
-										If you are worried or nervous or under pressure you can make hasty options 
-										and usually they aren't the best and can cost you a life, an objective or 
+										<b>Stay calm</b>. This means in every situation. Don't get worried, stay calm
+										and concentrate. If you stay calm you find it easier to control your actions.
+										If you are worried or nervous or under pressure you can make hasty options
+										and usually they aren't the best and can cost you a life, an objective or
 										even the game.
 									</li>
+									<br>
 									<li>
-										<b>Watch out for corners</b>. Basically if you have a corner set out like 
-										this <a href="http://i.imgur.com/6O2CHIi.jpg">http://i.imgur.com/6O2CHIi.jpg</a> 
-										then your arm or leg can pop out of it. You can get hit or shot from this so 
-										either stay a bit away or put an extra 2 blocks in front so it doesn't glitch 
-										out. Also if you see something like that watch out for an arm or a leg, you 
-										can shoot/hit it and cause damage. This can kill people and is often why 
+										<b>Watch out for corners</b>. Basically if you have a corner set out like
+										this <a href="http://i.imgur.com/6O2CHIi.jpg">http://i.imgur.com/6O2CHIi.jpg</a>
+										then your arm or leg can pop out of it. You can get hit or shot from this so
+										either stay a bit away or put an extra 2 blocks in front so it doesn't glitch
+										out. Also if you see something like that watch out for an arm or a leg, you
+										can shoot/hit it and cause damage. This can kill people and is often why
 										people accuse others of saying 'You can hit through walls'.
 									</li>
+									<br>
 									<li>
-										<b>Set your sprint key to something you're comfortable with</b>. Seriously, 
-										the amount&nbsp;people who &nbsp;complain about having a tired pinky cos 
-										they're pressing left control down all the time is too damn high. Mess 
-										around and set it to something you're comfortable with, be it R, a button on 
-										your mouse, a number etc. It helps a lot and you can keep it up for a long 
+										<b>Set your sprint key to something you're comfortable with</b>. Seriously,
+										the amount&nbsp;of people who &nbsp;complain about having a tired pinky cos
+										they're pressing left control down all the time is too damn high. Mess
+										around and set it to something you're comfortable with, be it Tab, R, a button on
+										your mouse, a number, etc. It helps a lot and you can keep it up for a long
 										time. R is a really good key because you can easily reach and <b>hold it</b>.
 									</li>
+									<br>
 									<li>
-										<b>Mess around with Minecraft</b>. Find something you're comfortable with all 
-										round. FOV, View bobbing on and off, your sensitivity (also check the dpi on 
-										your mouse and put it to something you're comfortable with (if that is 
-										possible on your mouse)). I mean I use Normal FOV, view bobbing off and 
-										128% sensitivity with 1800 on my mouse dpi. People use a whole lot of 
+										<b>Mess around with Minecraft</b>. Find something you're comfortable with all
+										round. FOV, View bobbing on and off, your sensitivity (also check the dpi on
+										your mouse and put it to something you're comfortable with (if that is
+										possible on your mouse)). I mean I use Normal FOV, view bobbing off and
+										128% sensitivity with 1800 on my mouse dpi. People use a whole lot of
 										different variations.
 									</li>
+									<br>
 									<li>
-										<b>Don't follow others, make your own path</b>. OK I know this contradicts 
-										the pvp guide but you need to know stuff in order to find out what you're 
-										good at. Don't follow someone like HattoWolf and whilst you may be good at 
-										one thing, you're bad at another. Combine things, test things, it is what 
+										<b>Don't follow others, make your own path</b>. OK I know this contradicts
+										the pvp guide but you need to know stuff in order to find out what you're
+										good at. Don't follow someone like HattoWolf and whilst you may be good at
+										one thing, you're bad at another. Combine things, test things, it is what
 										every 'pro' does.
 									</li>
+									<br>
 									<li>
-										<b>Be unpredictable whilst being able to predict others</b>. This all comes 
-										from experience and practice but allows you to get the edge over others 
+										<b>Be unpredictable whilst being able to predict others</b>. This all comes
+										from experience and practice but allows you to get the edge over others
 										before the fight even starts.
 									</li>
+									<br>
 									<li>
-										<b>Inventory layout</b>. Get yourself an inventory layout that suits 
-										you best. It can often help in the tight situations so you can get your items 
-										quicker. (Also when getting an item, use the soup method. This is shift and 
-										left click and right click (basically like shifting whilst block hitting) 
+										<b>Inventory layout</b>. Get yourself an inventory layout that suits
+										you best. It can often help in the tight situations so you can get your items
+										quicker. (Also when getting an item, use the soup method. This is shift and
+										left click and right click (basically like shifting whilst block hitting)
 										instead of normal shift left click. It is just quicker)
 									</li>
+									<br>
 									<li>
-										<b>Learn to hotkey</b>. Hot keying allows you to get to your item faster 
-										without having to scroll to it. It is a lot faster and allows for a quick 
-										item switch. Hot keying is basically pressing the numbers on your keyboard 
+										<b>Learn to hotkey</b>. Hot keying allows you to get to your item faster
+										without having to scroll to it. It is a lot faster and allows for a quick
+										item switch. Hot keying is basically pressing the numbers on your keyboard
 										(or mouse if mmo) and getting to that item.
 									</li>
+									<br>
 									<li>
-										<b>Keep warm</b>. By keeping warm, you keep good blood flow to your fingers 
-										and hands. If not then they slow down because blood is needed else where, 
+										<b>Keep warm</b>. By keeping warm, you keep good blood flow to your fingers
+										and hands. If not then they slow down because blood is needed else where,
 										this slows down your reflex and clicking ability and makes you a lot slower.
 									</li>
+									<br>
 									<li>
-										<b>Listen to music</b>. It allows you to relax, concentrate and shut off from 
-										outside irritations. I enjoy it and I find I fight better whilst listening to 
+										<b>Listen to music</b>. It allows you to relax, concentrate and shut off from
+										outside irritations. I enjoy it and I find I fight better whilst listening to
 										it.
 									</li>
+									<br>
 									<li>
-										<b>Stick in near/close to a group</b>. Don't stay in a group as it isn't that 
-										fun but if you stay close to a group they will usually help you out in 
+										<b>Stick in near/close to a group</b>. Don't stay in a group as it isn't that
+										fun but if you stay close to a group they will usually help you out in
 										situations where you'll probably die.
 									</li>
+									<br>
 									<li>
-										<b>Talk to friends</b>. By going on TS, Mumble or Skype with your friends you 
-										get more relaxed and find yourself doing more daring things. It just allows 
-										you to shut off a bit whilst having a good time and you can use teamwork to 
+										<b>Talk to friends</b>. By going on TS, Mumble or Skype with your friends you
+										get more relaxed and find yourself doing more daring things. It just allows
+										you to shut off a bit whilst having a good time and you can use teamwork to
 										help you.
 									</li>
+									<br>
 									<li>
-										<b>Get good at parkour</b>. By getting better at parkour, you understand 
-										terrain better. By putting parkour and pvp ability together, you become a 
-										master of terrain. You will be able to analyse situations quickly and bring 
+										<b>Get good at parkour</b>. By getting better at parkour, you understand
+										terrain better. By putting parkour and pvp ability together, you become a
+										master of terrain. You will be able to analyse situations quickly and bring
 										your enemy into situations where you can kill them.
 									</li>
+									<br>
 									<li>
-										<b>Mods</b>. Mods such as optifine, allow for a fps boost and allow you to 
-										change settings to allow for an optimal performance. Mods such as Reis 
-										Minimap allow for analysing terrain quickly. Mods such as Status effect 
-										and armor effect allow for quick checking of item status and any potion 
-										effects you may have. Also BSM helps by not having to tire out your finger 
-										(only use if server allows it) but 1.7 also has numerous advantages over 
-										BSM (search a video on it) e.g. 
-										<a href="https://www.youtube.com/watch?v=h5DoWh67AjE">https://www.youtube.com/watch?v=h5DoWh67AjE</a> 
+										<b>Mods</b>. Mods such as optifine, allow for a fps boost and allow you to
+										change settings to allow for an optimal performance. Mods such as Reis
+										Minimap allow for analysing terrain quickly. Mods such as Status effect
+										and armor effect allow for quick checking of item status and any potion
+										effects you may have. Also BSM helps by not having to tire out your finger
+										(only use if server allows it) but 1.7 also has numerous advantages over
+										BSM (search a video on it) e.g.
+										<a href="https://www.youtube.com/watch?v=h5DoWh67AjE">https://www.youtube.com/watch?v=h5DoWh67AjE</a>
 										Basically mods are a lot more helpful than first thought.<br>
 										<u><b>Remember to always observe the <a href="https://oc.tc/rules/en">rules</a> for mods (section F).</b></u>
 									</li>
+									<br>
 									<li>
-										<b>Resource packs</b>. By finding a resource pack (mainly pvp) that you like 
+										<b>Resource packs</b>. By finding a resource pack (mainly pvp) that you like
 										you find yourself doing better, I don't know why but you just do.
 									</li>
+									<br>
 									<li>
-										<b>Good mouse and keyboard</b>. I would advise against this if you're just 
-										gonna play minecraft but if not then get a better keyboard and mouse. It 
-										allows for easier control and you find yourself playing a lot better. 
+										<b>Good mouse and keyboard</b>. I would advise against this if you're just
+										gonna play minecraft but if not then get a better keyboard and mouse. It
+										allows for easier control and you find yourself playing a lot better.
 										(Also if you can a new computer helps A LOT too)
 									</li>
+									<br>
 									<li>
-										<b>Stay hydrated</b>. By staying hydrated you allow more activity in your 
+										<b>Stay hydrated</b>. By staying hydrated you allow more activity in your
 										brain which allows you to be faster all round.
 									</li>
+									<br>
 									<li>
-										<b>Confidence</b>. Believe that you can win. Confidence is a huge factor in 
-										pvp. If you think you're gonna lose, then you'll most likely lose, if you 
-										convince yourself you're gonna win and you're going to obliterate/dominate 
-										them then the chances of winning are high. NOBODY and I mean NOBODY is 
-										bad at everything in Minecraft, to get good at everything you need patience, 
+										<b>Confidence</b>. Believe that you can win. Confidence is a huge factor in
+										pvp. If you think you're gonna lose, then you'll most likely lose, if you
+										convince yourself you're gonna win and you're going to obliterate/dominate
+										them then the chances of winning are high. NOBODY and I mean NOBODY is
+										bad at everything in Minecraft, to get good at everything you need patience,
 										practice and experience.&nbsp;Believe in yourself!
 									</li>
 								</ul>
@@ -923,35 +937,37 @@
 								<br>
 								<ul>
 									<li>
-										<b>Potion pvp</b>&nbsp;(kohi, badlion, HCF)&nbsp;allows you to perfect 
-										different skills and is the one where you will get better at pvp the fastest. 
-										It takes time but you will get there soon enough. It isn't everyones liking 
-										at the start but give it time. Potion pvp puts everything from the 3 main 
+										<b>Potion pvp</b>&nbsp;(kohi, badlion, HCF)&nbsp;allows you to perfect
+										different skills and is the one where you will get better at pvp the fastest.
+										It takes time but you will get there soon enough. It isn't everyones liking
+										at the start but give it time. Potion pvp puts everything from the 3 main
 										types into one. It is usually where the best pvpers hang around too.
 									</li>
+									<br>
 									<li>
-										<b>Soup pvp&nbsp;</b>(mcpvp, mckits)&nbsp;allows for a better understanding 
-										of health management, hot keying, inventory layout and understanding of 
+										<b>Soup pvp&nbsp;</b>(mcpvp, mckits)&nbsp;allows for a better understanding
+										of health management, hot keying, inventory layout and understanding of
 										block hitting.&nbsp;
 									</li>
+									<br>
 									<li>
-										<b>Non-Enchant</b>&nbsp;(Avicus, OCN) allows for better crowd control, 
+										<b>Non-Enchant</b>&nbsp;(Avicus, OCN) allows for better crowd control,
 										inventory management, understanding of basic pvp and health management.
 									</li>
 								</ul>
 								<br>
 								The best thing to do though is to&nbsp;<b><i>PRACTICE, PRACTICE, PRACTICE!</i></b>
 								<br>
-								3 things what every 'pro' pvper has and uses on the battlefield 
+								3 things what every 'pro' pvper has and uses on the battlefield
 								<b>patience, practice and&nbsp;experience</b>.
 								<br><br>
 								<b><u>Glitches</u></b>
 								<br>
 								<ul>
 									<li>
-										<b>Can't hit your opponent</b>&nbsp;<b>even though your crosshair is on 
-										them</b>. This is most likely because you have a glitch where your sword 
-										blocks but it isn't. It glitches you out and you can't hit anyone. To get 
+										<b>Can't hit your opponent</b>&nbsp;<b>even though your crosshair is on
+										them</b>. This is most likely because you have a glitch where your sword
+										blocks but it isn't. It glitches you out and you can't hit anyone. To get
 										rid of it just click off it and then hot key back onto your sword.
 									</li>
 								</ul>
@@ -998,7 +1014,7 @@
 								<div>
 									<div>
 										<div>
-											mc.badlion.net - use no armor but feather falling boots, bring a lot of 
+											mc.badlion.net - use no armor but feather falling boots, bring a lot of
 											ender pearls and speed pots. Oh and obviously a bow.
 										</div>
 										<div>
@@ -1006,11 +1022,11 @@
 										</div>
 									</div>
 								</div>
-								<b><u>Rumours (Not sure if true or not)</u></b>
+								<b><u>Rumours</u></b>
 								<br>
 								<ul>
 									<li>
-										If you shift, you increase your hit length and you decrease your knockback. 
+										If you shift, you increase your hit length and you decrease your knockback.
 										(<b>False increase reach, true decrease knockback</b>)
 									</li>
 									<li>


### PR DESCRIPTION
This pull request breaks up the text that you see in the tips section.  It also removes four YouTube channels, as two do not exist anymore, one does not have any videos, and another does not have any Minecraft videos.  It also changes the moderator star to a flair, and some general fixes.

This also adds me as a contributor.
